### PR TITLE
make wayland default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ LABEL maintainer="thelamer"
 
 # title
 ENV TITLE=MAME \
-    NO_DECOR=true
+    NO_DECOR=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -11,7 +11,8 @@ LABEL maintainer="thelamer"
 
 # title
 ENV TITLE=MAME \
-    NO_DECOR=true
+    NO_DECOR=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/README.md
+++ b/README.md
@@ -615,5 +615,6 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **05.03.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **20.12.25:** - Add Wayland init logic.
 * **03.07.25:** - Initial release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -108,5 +108,6 @@ init_diagram: |
   "mame:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "05.03.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "20.12.25:", desc: "Add Wayland init logic."}
   - {date: "03.07.25:", desc: "Initial release."}


### PR DESCRIPTION
This flags the image to run in Wayland mode by default.

Wayland has some oddities and external setup for Nvidia, but in general is a night and day difference for an accelerated session.

I am starting with the series of gaming focused images where things like international keyboard or other bugs do not matter. This can be easily disabled as these repositories have existing X11 init logic you just flag it in the env to go back.